### PR TITLE
Check in default location if pixi not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
           environments: ${{ matrix.environment }}
       - run: pixi run fmt-check
       - run: pixi run lint-check
-      - run: pixi run test
+      - run: pixi run test --color=yes

--- a/conda
+++ b/conda
@@ -11,15 +11,24 @@ import traceback
 from functools import lru_cache
 from pathlib import Path
 
+ON_WINDOWS = os.name == "nt"
 ENABLE_LOGGING = True
 
 # assuming __file__ is .pixi/envs/<env>/libexec/conda
 # or .pixi\envs\<env>\libexec\conda.bat\..\conda.py
 PIXI_ENVIRONMENT_FILE = Path(__file__).resolve().parent.parent / "conda-meta" / "pixi"
+DEFAULT_PIXI_EXECUTABLE_PATH = (
+    Path(Path.home()) / ".pixi" / "bin" / f"pixi{'.exe' if ON_WINDOWS else ''}"
+)
 
 
 def pixi(cmd):
-    out = subprocess.check_output(["pixi", *cmd])
+    try:
+        out = subprocess.check_output(["pixi", *cmd])
+    except FileNotFoundError:
+        # if pixi is not on PATH, try to run it from the default location
+        # see https://pixi.sh/install.sh or https://pixi.sh/install.ps1
+        out = subprocess.check_output([str(DEFAULT_PIXI_EXECUTABLE_PATH), *cmd])
     return out.decode(locale.getpreferredencoding())
 
 

--- a/conda
+++ b/conda
@@ -25,10 +25,14 @@ DEFAULT_PIXI_EXECUTABLE_PATH = (
 def pixi(cmd):
     try:
         out = subprocess.check_output(["pixi", *cmd])
-    except FileNotFoundError:
+    except FileNotFoundError as e:
         # if pixi is not on PATH, try to run it from the default location
         # see https://pixi.sh/install.sh or https://pixi.sh/install.ps1
-        out = subprocess.check_output([str(DEFAULT_PIXI_EXECUTABLE_PATH), *cmd])
+        try:
+            out = subprocess.check_output([str(DEFAULT_PIXI_EXECUTABLE_PATH), *cmd])
+        except FileNotFoundError:
+            msg = "pixi not found. Is it installed in your PATH?"
+            raise FileNotFoundError(msg) from e
     return out.decode(locale.getpreferredencoding())
 
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixi-pycharm"
-version = "0.0.6"
+version = "0.0.7"
 description = "Conda shim for PyCharm that proxies pixi"
 authors = ["Pavel Zwerschke <pavelzw@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/ide_integration/pycharm.md as well

closes #20