### PR TITLE
Add pixi updates to dependency release notes section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,6 +21,7 @@ changelog:
     - title: ⬆️ Dependency updates
       labels:
         - dependencies
+        - pixi
     - title: 🤷🏻 Other changes
       labels:
         - "*"


### PR DESCRIPTION
If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/ide_integration/pycharm.md as well
