### PR TITLE
Check in default location if pixi not found (#41)

### DIFF
--- a/conda
+++ b/conda
@@ -117,14 +117,18 @@ def conda_run(args):
         pixi_run_args = [f'"{arg}"' for arg in args[3:] if arg != "--no-capture-output"]
     else:
         pixi_run_args = [arg for arg in args[3:] if arg != "--no-capture-output"]
-    os.execlp(
-        "pixi",
-        "pixi",
-        "run",
-        *std_pixi_args(),
-        *pixi_env_cli_params(env),
-        *pixi_run_args,
-    )
+
+    cmd = ["pixi", "run", *std_pixi_args(), *pixi_env_cli_params(env), *pixi_run_args]
+    try:
+        os.execlp("pixi", *cmd)
+    except FileNotFoundError as e:
+        # if pixi is not on PATH, try to run it from the default location
+        # see https://pixi.sh/install.sh or https://pixi.sh/install.ps1
+        try:
+            os.execlp(str(DEFAULT_PIXI_EXECUTABLE_PATH), *cmd)
+        except FileNotFoundError:
+            msg = "pixi not found. Is it installed in your PATH?"
+            raise FileNotFoundError(msg) from e
 
 
 def main(args):

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pixi-pycharm"
-version = "0.0.7"
+version = "0.0.8"
 description = "Conda shim for PyCharm that proxies pixi"
 authors = ["Pavel Zwerschke <pavelzw@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
Closes #41. This is a follow-up to #38.

This PR further fixes shim behaviour when pixi is not detected on the path by PyCharm. Added logic is duplicated from #38, I didn't see a better to factor this.

If updating documentation:

- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/ide_integration/pycharm.md as well
