### PR TITLE
docs: fix typo in PyCharm integration doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can then specify the corresponding environment in the bottom right corner of
 ### Multiple pixi projects
 
 When using multiple pixi projects, remember to select the correct _Conda Executable_ for each project as mentioned above.
-It also might come up that you have multiple environments it might come up that you have multiple environments with the same name.
+It also might come up that you have multiple environments with the same name.
 
 ![Multiple default environments](./.github/assets/multiple-default-envs-light.png#gh-light-mode-only)
 ![Multiple default environments](./.github/assets/multiple-default-envs-dark.png#gh-dark-mode-only)


### PR DESCRIPTION
If updating documentation:

- [x] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/ide_integration/pycharm.md as well
