### PR TITLE
Implement case ["env", "list", "--json"]

### DIFF
--- a/conda
+++ b/conda
@@ -152,7 +152,7 @@ def main(args):
             )
             return 1
         print("Self-check successful.", file=sys.stderr)
-    elif args == ["info", "--envs", "--json"]:
+    elif args in (["info", "--envs", "--json"], ["env", "list", "--json"]):
         conda_info_envs_json()
     elif args[0] == "list":
         conda_list(args)


### PR DESCRIPTION
- which is used by CLion 2025.3 EAP
- conda version 25.7.0 returns the same json as for ["info", "--envs", "--json"]


<img width="1056" height="623" alt="2025-09-22_13h19_39" src="https://github.com/user-attachments/assets/5ea775b9-b764-4be2-9e9d-be917bfc5d6c" />
