### PR TITLE
fix: add support Pixi 0.71+ rich platforms

### DIFF
--- a/conda
+++ b/conda
@@ -70,10 +70,22 @@ def pixi_json(cmd):
 
 
 def pixi_envs():
-    platform = pixi_json(["info", *std_pixi_args()])["platform"]
-    envs = pixi_json(["info", *std_pixi_args()])["environments_info"]
-    return [env["prefix"] for env in envs if platform in env["platforms"]]
+    info = pixi_json(["info", *std_pixi_args()])
+    platform = info["platform"]
+    envs = info["environments_info"]
+    return [
+        env["prefix"]
+        for env in envs
+        if platform in {pixi_platform_name(p) for p in env["platforms"]}
+    ]
 
+
+def pixi_platform_name(platform):
+    if isinstance(platform, str):
+        return platform
+    if isinstance(platform, dict):
+        return platform.get("name") or platform.get("subdir")
+    return None
 
 def print_json(data):
     print(json.dumps(data, indent=4))

--- a/conda
+++ b/conda
@@ -87,6 +87,7 @@ def pixi_platform_name(platform):
         return platform.get("name") or platform.get("subdir")
     return None
 
+
 def print_json(data):
     print(json.dumps(data, indent=4))
 


### PR DESCRIPTION
Add support for newer versions of Pixi while keep compatibility with versions below 0.71.0.

Pixi introduced rich platform in version [v0.71.0](https://github.com/prefix-dev/pixi/releases#release-v0.71.0), which change the output structure of `pixi info --json` from
```
"platforms": [
    "win-64"
]
```
into
```
"platforms": [ 
  { 
    "name": "win-64", 
    "subdir": "win-64", 
    "virtual_packages": [] 
  }
]
```


If updating documentation:
No documentation update needed
- [ ] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/integration/editor/pycharm.md as well
